### PR TITLE
Add Azure DNS private resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A sample implementation of a PKI with a standalone Certificate Authority with [s
   - [ ] [autocert](https://github.com/smallstep/autocert)
   - [ ] [Virtual Machines](https://smallstep.com/blog/embarrassingly-easy-certificates-on-aws-azure-gcp/)
   - [ ] [ACME clients](https://smallstep.com/docs/tutorials/acme-protocol-acme-clients)
+  - [ ] [cert-manager](https://cert-manager.io/)
 - [ ] Review public access/firewall for services behind Private Endpoint 
 - [ ] Review Key Vault RBAC for minimum rights required
 - [ ] Review Step provisioners and Provisioner management <https://smallstep.com/docs/step-ca/provisioners#remote-provisioner-management>

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ az network bastion ssh -n $AZURE_BASTION -g $AZURE_RG_NAME \
   --target-resource-id $(az vm show -g $AZURE_RG_NAME --name $CA_VM_NAME -o tsv --query id)
 ```
 
+Finally, you can verify the daemon state with:
+
+```bash
+systemctl status step-ca
+```
+
 ## Requirements
 
 Note: these are included in the provide dev container/codespaces.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ A sample implementation of a PKI with a standalone Certificate Authority with [s
     | CA_INIT_NAME | | CA Name |
     | CA_INIT_DNS | | The DNS fully qualified name of the CA |
     | CA_INIT_PROVISIONER_JWK | | The name of the default JWK provisioner|
+    | AZURE_DNS_RESOLVER_OUTBOUND_TARGET_DNS || A json object array of [targetdnsserver](https://docs.microsoft.com/en-us/rest/api/dns/dnsresolver/forwarding-rules/create-or-update?tabs=HTTP#targetdnsserver) objects.|
+    | AZURE_DNS_RESOLVER_OUTBOUND_DOMAIN | | the target domain with traling dot.|
 
     *For more information about the CA_INIT_ parameters, please refer to the [step ca init documentation](https://smallstep.com/docs/step-cli/reference/ca/init).*  
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ az network bastion ssh -n $AZURE_BASTION -g $AZURE_RG_NAME \
   --target-resource-id $(az vm show -g $AZURE_RG_NAME --name $CA_VM_NAME -o tsv --query id)
 ```
 
-Finally, you can verify the daemon state with:
+Once connected, you can verify the daemon state with:
 
 ```bash
 systemctl status step-ca

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ A sample implementation of a PKI with a standalone Certificate Authority with [s
 ## Backlog
 
 - [ ] Move the backlog to GitHub
-- [x] Add Private DNS Resolver
+- [ ] Add detailed deployment guidance, automation details and architecture diagram
+  - [ ] Add feature set details and mapping to Azure services.
 - [ ] Configure the [Azure Provisioner](https://smallstep.com/docs/step-ca/provisioners#azure)
 - [ ] Configure the [ACME provisioner](https://smallstep.com/docs/step-ca/provisioners/#acme)
 - [ ] Configure the [OAuth/OIDC provider with Azure AD](https://smallstep.com/docs/step-ca/provisioners#oauthoidc-single-sign-on)
-- [ ] Add detailed deployment guidance, automation details and architecture diagram
-  - [ ] Add feature set details and mapping to Azure services.
+
 - [ ] Add client scenarios, VM, AKS, https://github.com/shibayan/keyvault-acmebot
   - [ ] [autocert](https://github.com/smallstep/autocert)
   - [ ] [Virtual Machines](https://smallstep.com/blog/embarrassingly-easy-certificates-on-aws-azure-gcp/)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A sample implementation of a PKI with a standalone Certificate Authority with [s
   - [ ] [cert-manager](https://cert-manager.io/)
 - [ ] Review public access/firewall for services behind Private Endpoint 
 - [ ] Review Key Vault RBAC for minimum rights required
-- [ ] Review Step provisioners and Provisioner management <https://smallstep.com/docs/step-ca/provisioners#remote-provisioner-management>
+- [ ] Review Step provisioners and [Remote Provisioner management](https://smallstep.com/docs/step-ca/provisioners#remote-provisioner-management)
 - [ ] Add MySQL as Database
 - [ ] Test Azure Managed HSM and Azure Dedicated HSM
 - [ ] Add High Availability to MySQL  
@@ -35,8 +35,8 @@ A sample implementation of a PKI with a standalone Certificate Authority with [s
 - [ ] Add High Availability to step-ca  
 - [ ] Add VMSS base image
 - [ ] Azure Monitor support, metrics and logs
-- [ ] Add deploy to azure experience <https://techcommunity.microsoft.com/t5/azure-governance-and-management/using-azure-templatespecs-with-a-custom-ui/ba-p/3586173>
-- [ ] SSH and Azure AD SSO <https://smallstep.com/blog/diy-single-sign-on-for-ssh/>
+- [ ] Add Deploy to Azure portal experience
+- [ ] [SSH and Azure AD SSO](https://smallstep.com/blog/diy-single-sign-on-for-ssh)
 - [ ] AKS version [smallstep/step-ca](https://hub.docker.com/r/smallstep/step-ca) and [Helm Chart](https://artifacthub.io/packages/helm/smallstep/step-certificates)
 
 ## Deploying the solution

--- a/README.md
+++ b/README.md
@@ -13,31 +13,30 @@ A sample implementation of a PKI with a standalone Certificate Authority with [s
 
 ## Backlog
 
-- [ ] Move the backlog to GitHub
-- [ ] Add detailed deployment guidance, automation details and architecture diagram
-  - [ ] Add feature set details and mapping to Azure services.
-- [ ] Configure the [Azure Provisioner](https://smallstep.com/docs/step-ca/provisioners#azure)
-- [ ] Configure the [ACME provisioner](https://smallstep.com/docs/step-ca/provisioners/#acme)
-- [ ] Configure the [OAuth/OIDC provider with Azure AD](https://smallstep.com/docs/step-ca/provisioners#oauthoidc-single-sign-on)
-
-- [ ] Add client scenarios, VM, AKS, https://github.com/shibayan/keyvault-acmebot
-  - [ ] [autocert](https://github.com/smallstep/autocert)
-  - [ ] [Virtual Machines](https://smallstep.com/blog/embarrassingly-easy-certificates-on-aws-azure-gcp/)
-  - [ ] [ACME clients](https://smallstep.com/docs/tutorials/acme-protocol-acme-clients)
-  - [ ] [cert-manager](https://cert-manager.io/)
-- [ ] Review public access/firewall for services behind Private Endpoint 
-- [ ] Review Key Vault RBAC for minimum rights required
-- [ ] Review Step provisioners and [Remote Provisioner management](https://smallstep.com/docs/step-ca/provisioners#remote-provisioner-management)
-- [ ] Add MySQL as Database
-- [ ] Test Azure Managed HSM and Azure Dedicated HSM
-- [ ] Add High Availability to MySQL  
-- [ ] Store password, ca.json and defaults.json
-- [ ] Add High Availability to step-ca  
-- [ ] Add VMSS base image
-- [ ] Azure Monitor support, metrics and logs
-- [ ] Add Deploy to Azure portal experience
-- [ ] [SSH and Azure AD SSO](https://smallstep.com/blog/diy-single-sign-on-for-ssh)
-- [ ] AKS version [smallstep/step-ca](https://hub.docker.com/r/smallstep/step-ca) and [Helm Chart](https://artifacthub.io/packages/helm/smallstep/step-certificates)
+* [ ] Move the backlog to GitHub
+* [ ] Add detailed deployment guidance, automation details and architecture diagram
+  * [ ] Add feature set details and mapping to Azure services.
+* [ ] Configure the [Azure Provisioner](https://smallstep.com/docs/step-ca/provisioners#azure)
+* [ ] Configure the [ACME provisioner](https://smallstep.com/docs/step-ca/provisioners/#acme)
+* [ ] Configure the [OAuth/OIDC provider with Azure AD](https://smallstep.com/docs/step-ca/provisioners#oauthoidc-single-sign-on)
+* [ ] Add client scenarios, VM, AKS, https://github.com/shibayan/keyvault-acmebot
+  * [ ] [autocert](https://github.com/smallstep/autocert)
+  * [ ] [Virtual Machines](https://smallstep.com/blog/embarrassingly-easy-certificates-on-aws-azure-gcp/)
+  * [ ] [ACME clients](https://smallstep.com/docs/tutorials/acme-protocol-acme-clients)
+  * [ ] [cert-manager](https://cert-manager.io/)
+* [ ] Review public access/firewall for services behind Private Endpoint 
+* [ ] Review Key Vault RBAC for minimum rights required
+* [ ] Review Step provisioners and [Remote Provisioner management](https://smallstep.com/docs/step-ca/provisioners#remote-provisioner-management)
+* [ ] Add MySQL as Database
+* [ ] Test Azure Managed HSM and Azure Dedicated HSM
+* [ ] Add High Availability to MySQL  
+* [ ] Store password, ca.json and defaults.json
+* [ ] Add High Availability to step-ca  
+* [ ] Add VMSS base image
+* [ ] Azure Monitor support, metrics and logs
+* [ ] Add Deploy to Azure portal experience
+* [ ] [SSH and Azure AD SSO](https://smallstep.com/blog/diy-single-sign-on-for-ssh)
+* [ ] AKS version [smallstep/step-ca](https://hub.docker.com/r/smallstep/step-ca) and [Helm Chart](https://artifacthub.io/packages/helm/smallstep/step-certificates)
 
 ## Deploying the solution
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ A sample implementation of a PKI with a standalone Certificate Authority with [s
 * [Integrations](https://smallstep.com/docs/step-ca/integrations)
 * [Provisioners](https://smallstep.com/docs/step-ca/provisioners)
 
-
 ## Backlog
 
 - [ ] Move the backlog to GitHub
-- [ ] Add Private DNS Resolver
+- [x] Add Private DNS Resolver
 - [ ] Configure the [Azure Provisioner](https://smallstep.com/docs/step-ca/provisioners#azure)
 - [ ] Configure the [ACME provisioner](https://smallstep.com/docs/step-ca/provisioners/#acme)
 - [ ] Configure the [OAuth/OIDC provider with Azure AD](https://smallstep.com/docs/step-ca/provisioners#oauthoidc-single-sign-on)
 - [ ] Add detailed deployment guidance, automation details and architecture diagram
+  - [ ] Add feature set details and mapping to Azure services.
 - [ ] Add client scenarios, VM, AKS, https://github.com/shibayan/keyvault-acmebot
   - [ ] [autocert](https://github.com/smallstep/autocert)
   - [ ] [Virtual Machines](https://smallstep.com/blog/embarrassingly-easy-certificates-on-aws-azure-gcp/)

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,5 +1,8 @@
 [[ -z "${AZURE_RG_NAME}" ]] && export AZURE_RG_NAME='pki'
 [[ -z "${AZURE_LOCATION}" ]] && export AZURE_LOCATION='westeurope'
+[[ -z "${AZURE_DNS_RESOLVER_OUTBOUND_TARGET_DNS}" ]] && export AZURE_DNS_RESOLVER_OUTBOUND_TARGET_DNS="[{\"ipAddress\": \"192.168.0.11\"},{\"ipAddress\": \"192.168.0.13\"}]"
+[[ -z "${AZURE_DNS_RESOLVER_OUTBOUND_DOMAIN}" ]] && export AZURE_DNS_RESOLVER_OUTBOUND_DOMAIN='test.com.'
+[[ -z "${CA_INIT_DNS}" ]] && export CA_INIT_DNS='your DNS fqdn'
 [[ -z "${CA_SSH_PUBLIC_KEY}" ]] && export CA_SSH_PUBLIC_KEY="$(cat ~/.ssh/id_rsa.pub)"
 [[ -z "${DB_ADMIN_PASSWORD}" ]] && export DB_ADMIN_PASSWORD='your Database admin password'
 [[ -z "${CA_INIT_NAME}" ]] && export CA_INIT_NAME='your CA Name'
@@ -16,4 +19,6 @@ az deployment group create -g $AZURE_RG_NAME -o none \
   --parameters ca_INIT_PASSWORD="$CA_INIT_PASSWORD" \
   --parameters ca_INIT_NAME="$CA_INIT_NAME" \
   --parameters ca_INIT_DNS="$CA_INIT_DNS" \
-  --parameters dbLoginPassword="$DB_ADMIN_PASSWORD"
+  --parameters dbLoginPassword="$DB_ADMIN_PASSWORD" \
+  --parameters dnsResolverOutboundTargetDNS="$AZURE_DNS_RESOLVER_OUTBOUND_TARGET_DNS" \
+  --parameters dnsResolverOutboundDNSDomainName="$AZURE_DNS_RESOLVER_OUTBOUND_DOMAIN"

--- a/infra/base/step-ca-infra.bicep
+++ b/infra/base/step-ca-infra.bicep
@@ -8,7 +8,7 @@ param tags object = {
 
 param galleryDeploy bool = false
 param virtualNetworkDeploy bool = true
-param dnsResolverDeploy bool = false
+param dnsResolverDeploy bool = true
 param keyvaultDeploy bool = true
 param bastionDeploy bool = true
 param databaseDeploy bool = false
@@ -40,7 +40,7 @@ param virtualNetworkName string = 'stepca'
 param virtualNetworkDNSServers array = []
 
 param dnsResolverName string = 'dnsresolver'
-param dnsResolverOutboundDNS array
+param dnsResolverOutboundTargetDNS array
 param dnsResolverOutboundDNSDomainName string
 
 param keyvaultName string
@@ -127,7 +127,7 @@ resource virtualnetwork 'Microsoft.Network/virtualNetworks@2022-01-01' = if (vir
   name: virtualNetworkName
   location: location
   properties: {
-    dhcpOptions: {
+    dhcpOptions: dnsResolverDeploy ? null : {
       dnsServers: virtualNetworkDNSServers
     }
     addressSpace: {
@@ -617,7 +617,7 @@ resource dnsForwardRules 'Microsoft.Network/dnsForwardingRulesets@2020-04-01-pre
   resource outbound 'forwardingRules@2020-04-01-preview' = {
     name: 'outbound'
     properties: {
-      targetDnsServers: dnsResolverOutboundDNS
+      targetDnsServers: dnsResolverOutboundTargetDNS
       domainName: dnsResolverOutboundDNSDomainName
     }
   }

--- a/infra/base/step-ca-infra.bicep
+++ b/infra/base/step-ca-infra.bicep
@@ -39,13 +39,8 @@ param imageRecommended object = {
 param virtualNetworkName string = 'stepca'
 
 param dnsResolverName string = 'dnsresolver'
-param dnsResolverOutboundDNS array = [
-  {
-    ipAddress: '192.168.0.1'
-    port: 53
-  }
-]
-param dnsResolverOutboundDNSDomainName string = 'test.com.'
+param dnsResolverOutboundDNS array
+param dnsResolverOutboundDNSDomainName string
 
 param keyvaultName string
 //@secure()

--- a/infra/base/step-ca-infra.bicep
+++ b/infra/base/step-ca-infra.bicep
@@ -44,9 +44,6 @@ param dnsResolverOutboundDNSDomainName string
 
 param keyvaultName string
 //@secure()
-//param caSecret string
-
-// Bastion host name
 
 param bastionName string = 'caBastion'
 param bastionSku string = 'Standard'

--- a/infra/base/step-ca-infra.bicep
+++ b/infra/base/step-ca-infra.bicep
@@ -8,7 +8,7 @@ param tags object = {
 
 param galleryDeploy bool = false
 param virtualNetworkDeploy bool = true
-param dnsResolverDeploy bool = true
+param dnsResolverDeploy bool = false
 param keyvaultDeploy bool = true
 param bastionDeploy bool = true
 param databaseDeploy bool = false
@@ -37,6 +37,7 @@ param imageRecommended object = {
 }
 
 param virtualNetworkName string = 'stepca'
+param virtualNetworkDNSServers array = []
 
 param dnsResolverName string = 'dnsresolver'
 param dnsResolverOutboundDNS array
@@ -127,7 +128,7 @@ resource virtualnetwork 'Microsoft.Network/virtualNetworks@2022-01-01' = if (vir
   location: location
   properties: {
     dhcpOptions: {
-      dnsServers: []
+      dnsServers: virtualNetworkDNSServers
     }
     addressSpace: {
       addressPrefixes: [

--- a/infra/base/step-ca-infra.bicep
+++ b/infra/base/step-ca-infra.bicep
@@ -31,7 +31,10 @@ param imageRecommended object = {
 
 param virtualNetworkDeploy bool = true
 param virtualNetworkName string = 'stepca'
-param virtualNetworkDNSServers array = []
+
+param dnsResolverName string = 'dnsresolver'
+param dnsResolverOutboundDNS array = []
+param dnsResolverOutboundDNSDomainName string
 
 param keyvaultDeploy bool = true
 param keyvaultName string
@@ -39,7 +42,7 @@ param keyvaultName string
 //param caSecret string
 
 // Bastion host name
-param bastionDeploy bool = true
+param bastionDeploy bool = false
 param bastionName string = 'caBastion'
 param bastionSku string = 'Standard'
 
@@ -59,6 +62,7 @@ param dbHighAvailability object = {
 param dbVersion string = '5.7'
 
 // CA Virtual Machine Parameters
+param caDeploy bool = false
 param caVMName string
 param caVMAdminUsername string = 'stepcaadmin'
 @description('SSH Key')
@@ -96,20 +100,18 @@ var caVMlinuxConfiguration = {
     publicKeys: [
       {
         path: '/home/${caVMAdminUsername}/.ssh/authorized_keys'
-        keyData: caPublicSshKey.properties.publicKey
+        keyData: caDeploy ? caPublicSshKey.properties.publicKey : null
       }
     ]
   }
 }
-
-//var cloudinit5 = replace(cloudinit4, '[STEP_CA_INIT_COMMAND]', caINIT_COMMAND)
 
 //load the cloudinit template and perform template replacements
 var cloudinit0 = caVMCustomData
 var cloudinit1 = replace(cloudinit0, '[STEP_CA_VERSION]', caSTEP_CA_VERSION)
 var cloudinit2 = replace(cloudinit1, '[STEP_CLI_VERSION]', caSTEP_CLI_VERSION)
 var cloudinit3 = replace(cloudinit2, '[caVMAdminUsername]', caVMAdminUsername)
-var cloudinit4 = replace(cloudinit3, '[AZURE_CLIENT_ID]', caManagedIdentity.properties.clientId)
+var cloudinit4 = replace(cloudinit3, '[AZURE_CLIENT_ID]', caDeploy ? caManagedIdentity.properties.clientId : '')
 var cloudinit5 = replace(cloudinit4, '[CA_KEYVAULTNAME]', keyvaultName)
 var cloudinit6 = replace(cloudinit5, '[CA_ROOT_KEY_NAME]', ca_INIT_ROOT_KEY_NAME)
 var cloudinit7 = replace(cloudinit6, '[CA_INT_KEY_NAME]', ca_INIT_INTERMEDIATE_KEY_NAME)
@@ -119,12 +121,12 @@ var cloudinit10 = replace(cloudinit9, '[CA_INIT_PORT]', ca_INIT_PORT)
 var cloudinit11 = replace(cloudinit10, '[CA_INIT_PROVISIONER_JWT]', ca_INIT_PROVISIONER_JWT)
 var cloudinit = cloudinit11
 
-resource pkiVirtualNetwork 'Microsoft.Network/virtualNetworks@2022-01-01' = if (virtualNetworkDeploy) {
+resource virtualnetwork 'Microsoft.Network/virtualNetworks@2022-01-01' = if (virtualNetworkDeploy) {
   name: virtualNetworkName
   location: location
   properties: {
     dhcpOptions: {
-      dnsServers: virtualNetworkDNSServers
+      dnsServers: []
     }
     addressSpace: {
       addressPrefixes: [
@@ -133,15 +135,36 @@ resource pkiVirtualNetwork 'Microsoft.Network/virtualNetworks@2022-01-01' = if (
     }
     subnets: [
       {
+        name: 'dns'
+        properties: {
+          addressPrefix: '10.0.254.0/24'
+          delegations: [
+            {
+              name: 'Microsoft.Network/dnsResolvers'
+              properties: {
+                serviceName: 'Microsoft.Network/dnsResolvers'
+              }
+            }
+          ]
+
+        }
+      }
+      {
+        name: 'AzureBastionSubnet'
+        properties: {
+          addressPrefix: '10.0.253.0/24'
+        }
+      }
+      {
         name: 'ca'
         properties: {
-          addressPrefix: '10.0.0.0/24'
+          addressPrefix: '10.0.1.0/24'
         }
       }
       {
         name: 'database'
         properties: {
-          addressPrefix: '10.0.1.0/24'
+          addressPrefix: '10.0.2.0/24'
           delegations: [
             {
               name: 'Microsoft.DBforMySQL/flexibleServers'
@@ -155,16 +178,17 @@ resource pkiVirtualNetwork 'Microsoft.Network/virtualNetworks@2022-01-01' = if (
       {
         name: 'keyvault'
         properties: {
-          addressPrefix: '10.0.2.0/24'
-        }
-      }
-      {
-        name: 'AzureBastionSubnet'
-        properties: {
           addressPrefix: '10.0.3.0/24'
         }
       }
     ]
+  }
+  resource subnetAzureBastion 'subnets' existing = {
+    name: 'AzureBastionSubnet'
+  }
+
+  resource subnetDns 'subnets' existing = {
+    name: 'dns'
   }
 
   resource subnetCA 'subnets' existing = {
@@ -179,12 +203,9 @@ resource pkiVirtualNetwork 'Microsoft.Network/virtualNetworks@2022-01-01' = if (
     name: 'keyvault'
   }
 
-  resource subnetAzureBastion 'subnets' existing = {
-    name: 'AzureBastionSubnet'
-  }
 }
 
-resource pipBastion 'Microsoft.Network/publicIPAddresses@2022-01-01' = if (bastionDeploy) {
+resource bastionPip 'Microsoft.Network/publicIPAddresses@2022-01-01' = if (bastionDeploy) {
   name: bastionName
   location: location
   tags: tags
@@ -217,10 +238,10 @@ resource bastion 'Microsoft.Network/bastionHosts@2022-01-01' = if (bastionDeploy
         name: 'IpConf'
         properties: {
           subnet: {
-            id: pkiVirtualNetwork::subnetAzureBastion.id
+            id: virtualnetwork::subnetAzureBastion.id
           }
           publicIPAddress: {
-            id: pipBastion.id
+            id: bastionPip.id
           }
         }
       }
@@ -228,7 +249,7 @@ resource bastion 'Microsoft.Network/bastionHosts@2022-01-01' = if (bastionDeploy
   }
 }
 
-resource caKeyvault 'Microsoft.KeyVault/vaults@2022-07-01' = if (keyvaultDeploy) {
+resource keyvault 'Microsoft.KeyVault/vaults@2022-07-01' = if (keyvaultDeploy) {
   name: keyvaultName
   location: location
   tags: tags
@@ -249,13 +270,6 @@ resource caKeyvault 'Microsoft.KeyVault/vaults@2022-07-01' = if (keyvaultDeploy)
     }
     tenantId: subscription().tenantId
   }
-
-  // resource keyVaultSecret 'secrets@2019-09-01' = {
-  //   name: 'caSecret'
-  //   properties: {
-  //     value: caINIT_PASSWORD
-  //   }
-  // }
 }
 
 resource keyvaultPrivateEndpoint 'Microsoft.Network/privateEndpoints@2021-03-01' = if (keyvaultDeploy) {
@@ -266,13 +280,13 @@ resource keyvaultPrivateEndpoint 'Microsoft.Network/privateEndpoints@2021-03-01'
   ]
   properties: {
     subnet: {
-      id: pkiVirtualNetwork::subnetKeyvault.id
+      id: virtualnetwork::subnetKeyvault.id
     }
     privateLinkServiceConnections: [
       {
         name: 'caKeyvault'
         properties: {
-          privateLinkServiceId: caKeyvault.id
+          privateLinkServiceId: keyvault.id
           groupIds: [
             'vault'
           ]
@@ -307,35 +321,16 @@ resource keyvaultPrivateDNSZone 'Microsoft.Network/privateDnsZones@2020-06-01' =
     location: 'global'
     properties: {
       virtualNetwork: {
-        id: pkiVirtualNetwork.id
+        id: virtualnetwork.id
       }
       registrationEnabled: false
     }
   }
 }
 
-resource mysqlPrivateDNSZone 'Microsoft.Network/privateDnsZones@2020-06-01' = if (dbDeploy) {
-  name: 'privatelink.mysql.database.azure.com'
-  location: 'global'
-  tags: tags
-  properties: {}
-
-  resource linkVirtualNetwork 'virtualNetworkLinks@2020-06-01' = {
-    name: 'postgresToVirtualNetwork'
-    location: 'global'
-    properties: {
-      virtualNetwork: {
-        id: pkiVirtualNetwork.id
-      }
-      registrationEnabled: false
-    }
-  }
-}
-
-resource dbManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = if (dbDeploy) {
-  name: dbManagedIdentityName
-  location: location
-  tags: tags
+resource keyvaultAdminrole 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
+  scope: subscription()
+  name: '00482a5a-887f-4fb3-b363-3b7fe8e74483'
 }
 
 resource mysql 'Microsoft.DBforMySQL/flexibleServers@2021-05-01' = if (dbDeploy) {
@@ -352,10 +347,34 @@ resource mysql 'Microsoft.DBforMySQL/flexibleServers@2021-05-01' = if (dbDeploy)
     version: dbVersion
     highAvailability: dbHighAvailability
     network: {
-      delegatedSubnetResourceId: pkiVirtualNetwork::subnetDatabase.id
+      delegatedSubnetResourceId: virtualnetwork::subnetDatabase.id
       privateDnsZoneResourceId: mysqlPrivateDNSZone.id
     }
   }
+}
+
+resource mysqlPrivateDNSZone 'Microsoft.Network/privateDnsZones@2020-06-01' = if (dbDeploy) {
+  name: 'privatelink.mysql.database.azure.com'
+  location: 'global'
+  tags: tags
+  properties: {}
+
+  resource linkVirtualNetwork 'virtualNetworkLinks@2020-06-01' = {
+    name: 'postgresToVirtualNetwork'
+    location: 'global'
+    properties: {
+      virtualNetwork: {
+        id: virtualnetwork.id
+      }
+      registrationEnabled: false
+    }
+  }
+}
+
+resource mysqlManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = if (dbDeploy) {
+  name: dbManagedIdentityName
+  location: location
+  tags: tags
 }
 
 resource gallery 'Microsoft.Compute/galleries@2022-01-03' = if (galleryDeploy) {
@@ -367,7 +386,7 @@ resource gallery 'Microsoft.Compute/galleries@2022-01-03' = if (galleryDeploy) {
   }
 }
 
-resource galleryManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource galleryManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = if (galleryDeploy) {
   name: galleryManagedIdentityName
   location: location
   tags: tags
@@ -403,13 +422,13 @@ resource galleryImageBuilderRoleAssignment 'Microsoft.Authorization/roleAssignme
   name: guid(resourceGroup().id, subscription().id, 'Image Builder Service Image Contributor')
   scope: gallery
   properties: {
-    principalId: galleryManagedIdentity.properties.principalId
+    principalId: galleryDeploy ? galleryManagedIdentity.properties.principalId : ''
     roleDefinitionId: galleryImageBuilderRoleDefinition.id
     principalType: 'ServicePrincipal'
   }
 }
 
-resource stepcaImageDefinition 'Microsoft.Compute/galleries/images@2022-01-03' = if (galleryDeploy) {
+resource imageDefinitionCA 'Microsoft.Compute/galleries/images@2022-01-03' = if (galleryDeploy) {
   name: imageName
   location: location
   tags: tags
@@ -425,7 +444,7 @@ resource stepcaImageDefinition 'Microsoft.Compute/galleries/images@2022-01-03' =
   }
 }
 
-resource caPublicSshKey 'Microsoft.Compute/sshPublicKeys@2022-03-01' = {
+resource caPublicSshKey 'Microsoft.Compute/sshPublicKeys@2022-03-01' = if (caDeploy) {
   name: 'caVMSSHKey'
   location: location
   tags: tags
@@ -434,13 +453,13 @@ resource caPublicSshKey 'Microsoft.Compute/sshPublicKeys@2022-03-01' = {
   }
 }
 
-resource caManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource caManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = if (caDeploy) {
   name: caManagedIdentityName
   location: location
   tags: tags
 }
 
-resource cavmnic 'Microsoft.Network/networkInterfaces@2022-01-01' = {
+resource cavmnic 'Microsoft.Network/networkInterfaces@2022-01-01' = if (caDeploy) {
   name: '${caVMName}-nic'
   location: location
   tags: tags
@@ -450,7 +469,7 @@ resource cavmnic 'Microsoft.Network/networkInterfaces@2022-01-01' = {
         name: 'ipconfig1'
         properties: {
           subnet: {
-            id: pkiVirtualNetwork::subnetCA.id
+            id: virtualnetwork::subnetCA.id
           }
           privateIPAllocationMethod: 'Dynamic'
         }
@@ -462,7 +481,7 @@ resource cavmnic 'Microsoft.Network/networkInterfaces@2022-01-01' = {
   }
 }
 
-resource cavmnsg 'Microsoft.Network/networkSecurityGroups@2021-03-01' = {
+resource cavmnsg 'Microsoft.Network/networkSecurityGroups@2021-03-01' = if (caDeploy) {
   name: '${caVMName}-nsg'
   location: location
   properties: {
@@ -497,20 +516,20 @@ resource cavmnsg 'Microsoft.Network/networkSecurityGroups@2021-03-01' = {
   }
 }
 
-resource cavm 'Microsoft.Compute/virtualMachines@2022-03-01' = {
+resource cavm 'Microsoft.Compute/virtualMachines@2022-03-01' = if (caDeploy) {
   name: caVMName
   location: location
   tags: tags
   dependsOn: [
-    caKeyvault
+    keyvault
     cavmkeyvaultadmin
   ]
-  identity: {
+  identity: caDeploy ? {
     type: 'UserAssigned'
     userAssignedIdentities: {
       '${caManagedIdentity.id}': {}
     }
-  }
+  } : null
   properties: {
     hardwareProfile: {
       vmSize: caVMSize
@@ -548,30 +567,55 @@ resource cavm 'Microsoft.Compute/virtualMachines@2022-03-01' = {
       protectedSettings: {
         commandToExecute: 'echo "${ca_INIT_PASSWORD}" > /opt/stepcainstall/password.txt'
       }
-      // protectedSettingsFromKeyVault: {
-      //   keyVault: {
-      //     id: caKeyvault.id
-      //   }
-      //   "secretUrl":
-      // }
     }
   }
 }
 
-resource keyvaultAdminrole 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
-  scope: subscription()
-  name: '00482a5a-887f-4fb3-b363-3b7fe8e74483'
-}
-
-resource cavmkeyvaultadmin 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {
+resource cavmkeyvaultadmin 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = if (caDeploy) {
   name: guid(resourceGroup().id, subscription().id, 'Key Vault Administrator')
-  scope: caKeyvault
+  scope: keyvault
   properties: {
-    principalId: caManagedIdentity.properties.principalId
+    principalId: caDeploy ? caManagedIdentity.properties.principalId : ''
     roleDefinitionId: keyvaultAdminrole.id
     principalType: 'ServicePrincipal'
   }
 }
 
-output caManagedIdentityClientId string = caManagedIdentity.properties.clientId
+resource privateresolver 'Microsoft.Network/dnsResolvers@2020-04-01-preview' = if (virtualNetworkDeploy) {
+  name: dnsResolverName
+  location: location
+  properties: {
+    virtualNetwork: {
+      id: virtualnetwork.id
+    }
+  }
+
+  resource outboundEndpoints 'outboundEndpoints@2020-04-01-preview' = {
+    name: 'external'
+    location: location
+    properties: {
+      subnet: {
+        id: virtualnetwork::subnetDns.id
+      }
+    }
+  }
+}
+
+resource dnsForwardRules 'Microsoft.Network/dnsForwardingRulesets@2020-04-01-preview' = {
+  name: 'external'
+  location: location
+  properties: {
+    dnsResolverOutboundEndpoints: [ any(privateresolver::outboundEndpoints.id) ]
+  }
+
+  resource outbound 'forwardingRules@2020-04-01-preview' = {
+    name: 'outbound'
+    properties: {
+      targetDnsServers: dnsResolverOutboundDNS
+      domainName: dnsResolverOutboundDNSDomainName
+    }
+  }
+}
+
+output caManagedIdentityClientId string = caDeploy ? caManagedIdentity.properties.clientId : ''
 output caCloudInit string = cloudinit


### PR DESCRIPTION
Adds support for Azure DNS Private resolver with an outbound endpoint, target DNS servers and domain. This enables future support for dns-01 and http-01 challenges with the ACME provisioner, while maintaining compatibility with the Private DNS zones used in the solution to support Key Vault and MySQL Private Endpoints.